### PR TITLE
Rewrite template engine with Jinja2Cpp v2.6.0

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,9 @@
+# .JuliaFormatter.toml
+
+margin = 92                            # The maximum line length for code
+short_to_long_function_def = true      # Whether to use short or long function definitions
+always_use_return = true               # Whether to always use the return keyword in functions
+separate_kwargs_with_semicolon = false # Whether to separate keyword arguments with semicolons instead of commas
+join_lines_based_on_source = false     # Whether to join lines based on source code instead of formatting rules
+whitespace_in_kwargs = true            # Whether to include whitespace around keyword argument separators
+remove_extra_newlines = true           # Whether to remove extra newlines in code

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
-      - uses: julia-actions/setup-julia@v2
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/cache@v3
       - name: Configure CompatHelper
         run: |
           julia -e '
@@ -28,5 +28,4 @@ jobs:
             CompatHelper.main(use_existing_registries = true)
           '
         env:
-          GITHUB_TOKEN: ${{ github.token }} # Token required to create a pull request to the same repository
-          
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.8'
-          - '1.9'
+          - '1.10'
+          - '1.11'
         os:
           - ubuntu-latest
         arch:
@@ -36,15 +36,15 @@ jobs:
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -21,7 +21,7 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
       - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path = pwd())); Pkg.instantiate()'
       - name: Build and deploy
@@ -30,7 +30,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/Registry.yml
+++ b/.github/workflows/Registry.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   workflow_dispatch:
-    
+
 jobs:
   registry:
     name: Update registry
@@ -19,10 +19,10 @@ jobs:
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: 1.9
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Configure Git
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq git
@@ -32,13 +32,13 @@ jobs:
         run: |
           julia -e '
             using Pkg
-            
+
             Pkg.add("LocalRegistry")
             Pkg.develop(url = "git@github.com:${{ github.repository }}.git")
 
             using LocalRegistry
             using TOML
-    
+
             package_name = match(r"^.*/(.*?)(\.jl)?(\.git)?$", "${{ github.repository }}")
             package_name == nothing && error("Invalid package name: ${{ github.repository }}")
             package_name = package_name[1]
@@ -46,15 +46,14 @@ jobs:
             package_dir = joinpath(DEPOT_PATH[1], "dev", package_name)
             project_toml = TOML.parsefile(joinpath(package_dir, "Project.toml"))
             version = VersionNumber(project_toml["version"])
-    
+
             LocalRegistry.register(
                 package_name,
                 repo = "https://github.com/${{ github.repository }}.git",
                 registry = "git@github.com:bhftbootcamp/Green.git",
                 ignore_reregistration = true,
             )
-  
+
             run(Cmd(`git tag -f "v$version"`, dir = package_dir))
             run(Cmd(`git push --force origin "v$version"`, dir = package_dir))
             '
-            

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,12 @@
 name = "TemplateTools"
 uuid = "4b1000a4-b9b7-4319-98e4-c9b821a8e3b0"
-version = "2.5.0"
+version = "2.6.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Jinja2Cpp = "53d8605c-dcf1-482a-b927-58e959abfe3c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1.8"
+Jinja2Cpp = "0.1"
+julia = "1.10"

--- a/src/TemplateTools.jl
+++ b/src/TemplateTools.jl
@@ -3,8 +3,11 @@ module TemplateTools
 export create_project, default_templates
 
 using UUIDs
+using Dates
+using Jinja2Cpp
 
-const WITHOUT_RENDER = [".yml", ".ico"]
+const SKIP_RENDER_EXTENSIONS = [".yml", ".ico"]
+const INTERNAL_FIELDS = (:template_dir, :project_dir)
 
 function valid_package_name(package_name::String)
     if !occursin(r"^[A-Z].*$", package_name) || endswith(package_name, ".jl")
@@ -12,7 +15,7 @@ function valid_package_name(package_name::String)
             "Invalid package name: '$package_name'. Name must be in CamelCase and not end with '.jl'.",
         )
     else
-        package_name
+        return package_name
     end
 end
 
@@ -49,10 +52,31 @@ struct PkgTemplate
             version,
             join("@" .* owners, " "),
             join("@" .* maintainers, " "),
-            copyright_holder
+            copyright_holder,
         )
     end
 end
+
+function _template_values(template::PkgTemplate)
+    values = Dict{String,Any}()
+    for name in propertynames(template)
+        name in INTERNAL_FIELDS && continue
+        values[string(name)] = string(getproperty(template, name))
+    end
+    values["year"] = string(year(today()))
+    return values
+end
+
+function _render(source::String, values::Dict{String,Any}; name::String = "")
+    tmpl = Jinja2Template(source; name)
+    try
+        return jinja2_render(tmpl, values)
+    finally
+        close(tmpl)
+    end
+end
+
+_should_render(path::AbstractString) = !any(ext -> endswith(path, ext), SKIP_RENDER_EXTENSIONS)
 
 function create_project(
     template::PkgTemplate;
@@ -60,33 +84,27 @@ function create_project(
     repository_ssh_url::String,
     commit::Bool,
     push::Bool,
-    kw...,
 )
-    if !isdir(joinpath(DEPOT_PATH[1], "dev"))
-        mkdir(joinpath(DEPOT_PATH[1], "dev"))
-    end
-
     if !isdir(template.template_dir)
         error("The template directory $(template.template_dir) does not exist.")
     end
 
     if isdir(template.project_dir) || isfile(template.project_dir)
         error("The directory or file $(template.project_dir) already exists.")
-    else
-        mkdir(template.project_dir)
     end
+
+    mkpath(template.project_dir)
+    values = _template_values(template)
 
     for (root, dirs, files) in walkdir(template.template_dir)
         for file in files
             source_path = joinpath(root, file)
-            txt = read(source_path, String)
             source_name = relpath(source_path, template.template_dir)
-            if !any(endswith.(source_path, WITHOUT_RENDER))
-                for prop in propertynames(template)
-                    val = getfield(template, prop)
-                    txt = replace(txt, Regex("{{\\s*($prop)\\s*}}") => val)
-                    source_name = replace(source_name, Regex("{{\\s*($prop)\\s*}}") => val)
-                end
+            if _should_render(source_path)
+                txt = _render(read(source_path, String), values; name = source_name)
+                source_name = _render(source_name, values; name = "path")
+            else
+                txt = read(source_path)
             end
             target_path = joinpath(template.project_dir, source_name)
             mkpath(dirname(target_path))
@@ -95,24 +113,20 @@ function create_project(
     end
 
     if commit
-        run(Cmd(`git init -q`, dir = template.project_dir))
-        run(Cmd(`git remote add origin $(repository_ssh_url)`, dir = template.project_dir))
-        run(Cmd(`git branch -M $(branch)`, dir = template.project_dir))
-        run(Cmd(`git add .`, dir = template.project_dir))
-        run(
-            Cmd(
-                `git commit -qm "Create project $(template.package_name) 🤖"`,
-                dir = template.project_dir,
-            ),
-        )
-        push && run(Cmd(`git push -uf origin $(branch)`, dir = template.project_dir))
+        dir = template.project_dir
+        run(Cmd(`git init -q`; dir))
+        run(Cmd(`git remote add origin $(repository_ssh_url)`; dir))
+        run(Cmd(`git branch -M $(branch)`; dir))
+        run(Cmd(`git add .`; dir))
+        run(Cmd(`git commit -qm "Create project $(template.package_name) 🤖"`; dir))
+        push && run(Cmd(`git push -uf origin $(branch)`; dir))
     end
 
     return true
 end
 
 """
-    create_project(package_name::String; template::String, github_username::String, kw...)
+    create_project(; package_name, template, github_username, kw...)
 
 A function that generates a package named `package_name` using a given template.
 

--- a/templates/general/.github/workflows/CI.yml
+++ b/templates/general/.github/workflows/CI.yml
@@ -25,24 +25,22 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.8'
-          - '1.9'
           - '1.10'
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v5
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -57,9 +55,9 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(; path = pwd())); Pkg.instantiate();'
       - name: Build and deploy
@@ -68,7 +66,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/templates/general/.github/workflows/CompatHelper.yml
+++ b/templates/general/.github/workflows/CompatHelper.yml
@@ -4,15 +4,24 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
-  
+
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/cache@v3
+      - name: Configure CompatHelper
+        run: |
+          julia -e '
+            using Pkg
+            Pkg.add("CompatHelper")
+            using CompatHelper
+            CompatHelper.main()
+          '
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/templates/general/LICENSE
+++ b/templates/general/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 {{ copyright_holder }}
+Copyright (c) {{ year }} {{ copyright_holder }}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/templates/general/Project.toml
+++ b/templates/general/Project.toml
@@ -1,8 +1,8 @@
 name = "{{ package_name }}"
 uuid = "{{ uuid }}"
-version = "0.1.0"
+version = "{{ version }}"
 
 [deps]
 
 [compat]
-julia = "1.8"
+julia = "1.10"

--- a/templates/green/.JuliaFormatter.toml
+++ b/templates/green/.JuliaFormatter.toml
@@ -1,0 +1,9 @@
+# .JuliaFormatter.toml
+
+margin = 92                            # The maximum line length for code
+short_to_long_function_def = true      # Whether to use short or long function definitions
+always_use_return = true               # Whether to always use the return keyword in functions
+separate_kwargs_with_semicolon = false # Whether to separate keyword arguments with semicolons instead of commas
+join_lines_based_on_source = false     # Whether to join lines based on source code instead of formatting rules
+whitespace_in_kwargs = true            # Whether to include whitespace around keyword argument separators
+remove_extra_newlines = true           # Whether to remove extra newlines in code

--- a/templates/green/.github/workflows/CompatHelper.yml
+++ b/templates/green/.github/workflows/CompatHelper.yml
@@ -12,13 +12,13 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
-      - uses: julia-actions/setup-julia@v2
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/cache@v3
       - name: Configure CompatHelper
         run: |
           julia -e '
@@ -28,4 +28,4 @@ jobs:
             CompatHelper.main(use_existing_registries = true)
           '
         env:
-          GITHUB_TOKEN: ${{ github.token }} # Token required to create a pull request to the same repository
+          GITHUB_TOKEN: ${{ github.token }}

--- a/templates/green/.github/workflows/Coverage.yml
+++ b/templates/green/.github/workflows/Coverage.yml
@@ -24,27 +24,27 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.8'
-          - '1.9'
+          - '1.10'
+          - '1.11'
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/templates/green/.github/workflows/DocPreviewCleanup.yml
+++ b/templates/green/.github/workflows/DocPreviewCleanup.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
       - name: Delete preview and history + push changes

--- a/templates/green/.github/workflows/Documentation.yml
+++ b/templates/green/.github/workflows/Documentation.yml
@@ -15,13 +15,13 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
       - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path = pwd())); Pkg.instantiate()'
       - name: Build and deploy
@@ -30,7 +30,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/templates/green/.github/workflows/Registry.yml
+++ b/templates/green/.github/workflows/Registry.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   workflow_dispatch:
-    
+
 jobs:
   registry:
     name: Update registry
@@ -14,15 +14,15 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           registry: bhftbootcamp/Green
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: 1.9
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Configure Git
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq git
@@ -32,13 +32,13 @@ jobs:
         run: |
           julia -e '
             using Pkg
-            
+
             Pkg.add("LocalRegistry")
             Pkg.develop(url = "git@github.com:${{ github.repository }}.git")
 
             using LocalRegistry
             using TOML
-    
+
             package_name = match(r"^.*/(.*?)(\.jl)?(\.git)?$", "${{ github.repository }}")
             package_name == nothing && error("Invalid package name: ${{ github.repository }}")
             package_name = package_name[1]
@@ -46,14 +46,14 @@ jobs:
             package_dir = joinpath(DEPOT_PATH[1], "dev", package_name)
             project_toml = TOML.parsefile(joinpath(package_dir, "Project.toml"))
             version = VersionNumber(project_toml["version"])
-    
+
             LocalRegistry.register(
                 package_name,
                 repo = "https://github.com/${{ github.repository }}.git",
                 registry = "git@github.com:bhftbootcamp/Green.git",
                 ignore_reregistration = true,
             )
-  
+
             run(Cmd(`git tag -f "v$version"`, dir = package_dir))
             run(Cmd(`git push --force origin "v$version"`, dir = package_dir))
             '

--- a/templates/green/LICENSE
+++ b/templates/green/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 {{ copyright_holder }}
+Copyright (c) {{ year }} {{ copyright_holder }}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/templates/green/Project.toml
+++ b/templates/green/Project.toml
@@ -1,8 +1,8 @@
 name = "{{ package_name }}"
 uuid = "{{ uuid }}"
-version = "0.1.0"
+version = "{{ version }}"
 
 [deps]
 
 [compat]
-julia = "1.8"
+julia = "1.10"

--- a/templates/green/README.md
+++ b/templates/green/README.md
@@ -13,7 +13,7 @@
 If you haven't installed our [local registry](https://github.com/bhftbootcamp/Green) yet, do that first:
 
 ```
-] registry add https://github.com/{{ github_username }}/Green.git
+] registry add https://github.com/bhftbootcamp/Green.git
 ```
 
 To install {{ package_name }}, simply use the Julia package manager:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,163 @@
 
 using Test
 using TemplateTools
-using TemplateTools: valid_package_name
+using TemplateTools: valid_package_name, _template_values, _render, _should_render, PkgTemplate
 
-@testset verbose = true "Common tests" begin
-    @test valid_package_name("MyPkg") == "MyPkg"
-    @test valid_package_name("PrettyPkg") == "PrettyPkg"
-    @test_throws ErrorException valid_package_name("MyPkg.jl")
+@testset verbose = true "TemplateTools" begin
+
+    @testset "valid_package_name" begin
+        @test valid_package_name("MyPkg") == "MyPkg"
+        @test valid_package_name("PrettyPkg") == "PrettyPkg"
+        @test_throws ErrorException valid_package_name("MyPkg.jl")
+        @test_throws ErrorException valid_package_name("mypkg")
+    end
+
+    @testset "Jinja2 rendering" begin
+        @test _render("Hello, {{ name }}!", Dict{String,Any}("name" => "World")) ==
+              "Hello, World!"
+        @test _render("No placeholders", Dict{String,Any}()) == "No placeholders"
+        @test _render("{{ a }} and {{ b }}", Dict{String,Any}("a" => "X", "b" => "Y")) ==
+              "X and Y"
+    end
+
+    @testset "template values" begin
+        tmpl = PkgTemplate(
+            "TestPkg";
+            github_username = "testuser",
+            template = "general",
+        )
+        vals = _template_values(tmpl)
+        @test vals["package_name"] == "TestPkg"
+        @test vals["github_username"] == "testuser"
+        @test vals["version"] == "0.1.0"
+        @test vals["copyright_holder"] == "bhftbootcamp"
+        @test haskey(vals, "uuid")
+        @test haskey(vals, "year")
+        @test match(r"^\d{4}$", vals["year"]) !== nothing
+        @test !haskey(vals, "template_dir")
+        @test !haskey(vals, "project_dir")
+    end
+
+    @testset "should render" begin
+        @test _should_render("README.md") == true
+        @test _should_render("src/Foo.jl") == true
+        @test _should_render("LICENSE") == true
+        @test _should_render(".github/workflows/CI.yml") == false
+        @test _should_render("docs/src/assets/favicon.ico") == false
+    end
+
+    @testset "create_project general" begin
+        mktempdir() do dir
+            project_dir = joinpath(dir, "TestPkg")
+            create_project(
+                package_name = "TestPkg",
+                github_username = "testuser",
+                template = "general",
+                project_dir = project_dir,
+                commit = false,
+                push = false,
+            )
+
+            @test isfile(joinpath(project_dir, "Project.toml"))
+            @test isfile(joinpath(project_dir, "src", "TestPkg.jl"))
+            @test isfile(joinpath(project_dir, "README.md"))
+            @test isfile(joinpath(project_dir, "LICENSE"))
+            @test isfile(joinpath(project_dir, ".gitignore"))
+            @test isfile(joinpath(project_dir, ".JuliaFormatter.toml"))
+            @test isdir(joinpath(project_dir, "docs"))
+            @test isdir(joinpath(project_dir, ".github"))
+
+            project_toml = read(joinpath(project_dir, "Project.toml"), String)
+            @test occursin("name = \"TestPkg\"", project_toml)
+            @test !occursin("{{ package_name }}", project_toml)
+            @test !occursin("{{ uuid }}", project_toml)
+            @test !occursin("{{ version }}", project_toml)
+
+            readme = read(joinpath(project_dir, "README.md"), String)
+            @test occursin("TestPkg", readme)
+            @test occursin("testuser", readme)
+            @test !occursin("{{ package_name }}", readme)
+            @test !occursin("{{ github_username }}", readme)
+
+            src = read(joinpath(project_dir, "src", "TestPkg.jl"), String)
+            @test occursin("module TestPkg", src)
+
+            license = read(joinpath(project_dir, "LICENSE"), String)
+            @test occursin("bhftbootcamp", license)
+            @test !occursin("{{ copyright_holder }}", license)
+            @test !occursin("{{ year }}", license)
+
+            # YAML files are copied without rendering
+            ci_yml = read(joinpath(project_dir, ".github", "workflows", "CI.yml"), String)
+            @test occursin("\${{ matrix.version }}", ci_yml)
+        end
+    end
+
+    @testset "create_project green" begin
+        mktempdir() do dir
+            project_dir = joinpath(dir, "GreenPkg")
+            create_project(
+                package_name = "GreenPkg",
+                github_username = "bhftbootcamp",
+                template = "green",
+                project_dir = project_dir,
+                version = VersionNumber(0, 2, 0),
+                owners = ["user1"],
+                commit = false,
+                push = false,
+            )
+
+            @test isfile(joinpath(project_dir, "Project.toml"))
+            @test isfile(joinpath(project_dir, "src", "GreenPkg.jl"))
+            @test isfile(joinpath(project_dir, ".JuliaFormatter.toml"))
+
+            project_toml = read(joinpath(project_dir, "Project.toml"), String)
+            @test occursin("name = \"GreenPkg\"", project_toml)
+            @test occursin("version = \"0.2.0\"", project_toml)
+
+            @test isfile(joinpath(project_dir, ".github", "workflows", "Coverage.yml"))
+            @test isfile(joinpath(project_dir, ".github", "workflows", "Registry.yml"))
+            @test isfile(joinpath(project_dir, ".github", "workflows", "Documentation.yml"))
+            @test isfile(joinpath(project_dir, ".github", "workflows", "ReleaseTag.yml"))
+
+            codeowners = read(joinpath(project_dir, ".github", "CODEOWNERS"), String)
+            @test occursin("@user1", codeowners)
+        end
+    end
+
+    @testset "duplicate project error" begin
+        mktempdir() do dir
+            project_dir = joinpath(dir, "DupPkg")
+            create_project(
+                package_name = "DupPkg",
+                github_username = "testuser",
+                template = "general",
+                project_dir = project_dir,
+                commit = false,
+                push = false,
+            )
+            @test_throws ErrorException create_project(
+                package_name = "DupPkg",
+                github_username = "testuser",
+                template = "general",
+                project_dir = project_dir,
+                commit = false,
+                push = false,
+            )
+        end
+    end
+
+    @testset "invalid template error" begin
+        mktempdir() do dir
+            @test_throws ErrorException create_project(
+                package_name = "BadPkg",
+                github_username = "testuser",
+                template = "nonexistent",
+                project_dir = joinpath(dir, "BadPkg"),
+                commit = false,
+                push = false,
+            )
+        end
+    end
+
 end


### PR DESCRIPTION
## Summary

- Replaced regex-based `{{ variable }}` substitution with [Jinja2Cpp.jl](https://github.com/bhftbootcamp/Jinja2Cpp.jl) rendering engine
- Actualized all CI workflow templates to current bhftbootcamp standards
- Expanded test suite from 3 to 54 tests

## Changes

### Template engine
- `Jinja2Template` + `jinja2_render` instead of regex loop over struct fields
- Auto-derive template values from `PkgTemplate` via `propertynames` (no manual field mapping)
- `try/finally` for `Jinja2Template` resource cleanup
- Error context (file name) passed to Jinja2 rendering errors
- New dynamic variables: `{{ year }}` (LICENSE), `{{ version }}` (Project.toml)

### CI templates actualized
- `actions/checkout` v5 → v6
- `julia-actions/setup-julia` v2 → v3
- `julia-actions/cache` v2 → v3
- `codecov/codecov-action` v5 → v6
- `actions/github-script` v8 → v9
- Julia matrices: green `1/1.10/1.11`, general `1/1.10`
- Julia compat `1.8` → `1.10`

### Fixes
- Green README: hardcode `bhftbootcamp/Green.git` registry URL
- General `CompatHelper.yml`: add missing `checkout`, `setup-julia`, `cache`
- Add `.JuliaFormatter.toml` to green template (was only in general)
- Add `.JuliaFormatter.toml` to repo root

### Dependencies
- Added `Jinja2Cpp` (compat `0.1`) and `Dates`

## Test plan
- [x] 54 unit tests pass (valid_package_name, Jinja2 rendering, template values, should_render, create_project general/green, error cases)
- [x] End-to-end generation tested for both `green` and `general` templates
- [x] Verified generated files: Project.toml, README, LICENSE, src, CODEOWNERS, docs/make.jl, workflow YAMLs